### PR TITLE
[FIX]: Use Github Slugger in RichText headings

### DIFF
--- a/.changeset/clever-suits-yawn.md
+++ b/.changeset/clever-suits-yawn.md
@@ -1,0 +1,5 @@
+---
+"basehub": patch
+---
+
+React RichText component now implements GithubSlugger to generate the headings IDs

--- a/packages/basehub/package.json
+++ b/packages/basehub/package.json
@@ -39,11 +39,11 @@
     "arg": "5.0.1",
     "dotenv-mono": "1.3.10",
     "esbuild": "0.19.2",
+    "github-slugger": "^2.0.0",
     "pusher-js": "8.3.0",
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "resolve-pkg": "2.0.0",
-    "slugify": "1.6.6",
     "sonner": "1.4.3",
     "zod": "3.22.1"
   },

--- a/packages/basehub/src/react/rich-text/util/heading-id.ts
+++ b/packages/basehub/src/react/rich-text/util/heading-id.ts
@@ -14,15 +14,3 @@ export function extractTextFromNode(node?: Node) {
 
   return textContent;
 }
-
-export function incrementID(id: string) {
-  // duplicates are added "-n" at the end.
-  // if the title already has a "-n" at the end, we'll need to increment it.
-  const matches = id.match(/-(\d+)$/); // Fixed regex to match "-n" format
-  if (matches?.[1] !== undefined) {
-    const number = parseInt(matches[1], 10);
-    return id.replace(/-(\d+)$/, `-${number + 1}`);
-  }
-
-  return `${id}-1`;
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,9 +91,6 @@ importers:
       resolve-pkg:
         specifier: 2.0.0
         version: 2.0.0
-      slugify:
-        specifier: 1.6.6
-        version: 1.6.6
       sonner:
         specifier: 1.4.3
         version: 1.4.3(react-dom@18.2.0)(react@18.2.0)
@@ -4181,11 +4178,6 @@ packages:
     dependencies:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 4.0.0
-    dev: false
-
-  /slugify@1.6.6:
-    resolution: {integrity: sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==}
-    engines: {node: '>=8.0.0'}
     dev: false
 
   /smartwrap@1.2.5:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -76,6 +76,9 @@ importers:
       esbuild:
         specifier: 0.19.2
         version: 0.19.2
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       pusher-js:
         specifier: 8.3.0
         version: 8.3.0
@@ -2580,6 +2583,10 @@ packages:
 
   /github-from-package@0.0.0:
     resolution: {integrity: sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==}
+    dev: false
+
+  /github-slugger@2.0.0:
+    resolution: {integrity: sha512-IaOQ9puYtjrkq7Y0Ygl9KDZnrf/aiUJYUpVf89y8kyaxbRG7Y1SrX/jaumrv81vc61+kiMempujsM3Yw7w5qcw==}
     dev: false
 
   /glob-parent@5.1.2:


### PR DESCRIPTION
This PR resolves the issue of content IDs being out of sync with the TOC links by ensuring that both now use the same approach to generate heading IDs.

Fixes: [Bug: there are some TOC items that are not resolved, for example: https://documentation-git-bshb-improvements-scaleai.vercel.app/docs/api-reference/tasks#delete-unique_id](https://3.basecamp.com/5712750/buckets/36739894/todos/7272849623/edit?replace=true)