### PR TITLE
Pin `@radix-ui/react-slot` dependency to SemVer MAJOR

### DIFF
--- a/.changeset/sharp-pans-act.md
+++ b/.changeset/sharp-pans-act.md
@@ -1,0 +1,5 @@
+---
+"basehub": patch
+---
+
+Pin `@radix-ui/react-slot` dependency to SemVer MAJOR

--- a/packages/basehub/package.json
+++ b/packages/basehub/package.json
@@ -52,7 +52,7 @@
   "dependencies": {
     "@basehub/genql": "9.0.0-canary.1",
     "@basehub/mutation-api-helpers": "2.0.0",
-    "@radix-ui/react-slot": "1.0.2",
+    "@radix-ui/react-slot": "^1.1.0",
     "arg": "5.0.1",
     "dotenv-mono": "1.3.10",
     "esbuild": "0.19.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,8 +68,8 @@ importers:
         specifier: 2.0.0
         version: 2.0.0
       '@radix-ui/react-slot':
-        specifier: 1.0.2
-        version: 1.0.2(@types/react@18.2.20)(react@18.2.0)
+        specifier: ^1.1.0
+        version: 1.1.0(@types/react@18.2.20)(react@18.2.0)
       arg:
         specifier: 5.0.1
         version: 5.0.1
@@ -1033,31 +1033,29 @@ packages:
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
     dev: true
 
-  /@radix-ui/react-compose-refs@1.0.1(@types/react@18.2.20)(react@18.2.0):
-    resolution: {integrity: sha512-fDSBgd44FKHa1FRMU59qBMPFcl2PZE+2nmqunj+BWFyYYjnhIDWL2ItDs3rrbJDQOtzt5nIebLCQc4QRfz6LJw==}
+  /@radix-ui/react-compose-refs@1.1.0(@types/react@18.2.20)(react@18.2.0):
+    resolution: {integrity: sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.6
       '@types/react': 18.2.20
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-slot@1.0.2(@types/react@18.2.20)(react@18.2.0):
-    resolution: {integrity: sha512-YeTpuq4deV+6DusvVUW4ivBgnkHwECUu0BiN43L5UCDFgdhsRUWAghhTF5MbvNTPzmiFOx90asDSUjWuCNapwg==}
+  /@radix-ui/react-slot@1.1.0(@types/react@18.2.20)(react@18.2.0):
+    resolution: {integrity: sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==}
     peerDependencies:
       '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0
+      react: 19.0.0-rc.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
     dependencies:
-      '@babel/runtime': 7.24.6
-      '@radix-ui/react-compose-refs': 1.0.1(@types/react@18.2.20)(react@18.2.0)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.2.20)(react@18.2.0)
       '@types/react': 18.2.20
       react: 18.2.0
     dev: false


### PR DESCRIPTION
Pinning it to its patch version contributes to dependency duplication in applications using `basehub` and `@radix-ui/react-slot`. `@radix-ui/react-slot` is not known for violating SemVer so pinning the version to its major is safe.

This ensures fixes are propagated faster throughout the ecosystem. In this case, `@radix-ui/slot` published a fix for React 19 compat that `basehub` users won't get until a new `basehub` release is out. It helps us in the React team in gathering feedback quicker since we don't need to ensure each dependent updates its dependencies even when their dependencies can ensure compatibility with a SemVer MINOR.