### PR TITLE
Remove React from direct dependencies

### DIFF
--- a/.changeset/blue-fireants-warn.md
+++ b/.changeset/blue-fireants-warn.md
@@ -1,0 +1,5 @@
+---
+"basehub": patch
+---
+
+Remove React from direct dependencies in favor of existing peer dependency declaration.

--- a/packages/basehub/package.json
+++ b/packages/basehub/package.json
@@ -61,8 +61,6 @@
     "lodash.debounce": "^4.0.8",
     "lodash.get": "4.4.2",
     "pusher-js": "8.3.0",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
     "resolve-pkg": "2.0.0",
     "sonner": "1.4.3",
     "typesense": "1.8.2",
@@ -76,6 +74,8 @@
     "@types/react-dom": "18.2.7",
     "esbuild-scss-modules-plugin": "^1.1.1",
     "next": "^13.5.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
     "tsconfig": "workspace:*",
     "tsup": "8.0.2",
     "type-fest": "3.0.0"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -94,12 +94,6 @@ importers:
       pusher-js:
         specifier: 8.3.0
         version: 8.3.0
-      react:
-        specifier: 18.2.0
-        version: 18.2.0
-      react-dom:
-        specifier: 18.2.0
-        version: 18.2.0(react@18.2.0)
       resolve-pkg:
         specifier: 2.0.0
         version: 2.0.0
@@ -134,6 +128,12 @@ importers:
       next:
         specifier: ^13.5.3
         version: 13.5.3(react-dom@18.2.0)(react@18.2.0)
+      react:
+        specifier: 18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: 18.2.0
+        version: 18.2.0(react@18.2.0)
       tsconfig:
         specifier: workspace:*
         version: link:../../internal/tsconfig


### PR DESCRIPTION
A library must not use React as a direct dependency since it may result in duplicate versions of React being installed which is not supported. You already correctly have it declared as a peer dependency which is defeated by also declaring it in `dependencies`.

To test integration with React, it is now declared in `devDependencies`.